### PR TITLE
disable automatic window renaming

### DIFF
--- a/files/tmux.conf
+++ b/files/tmux.conf
@@ -5,6 +5,8 @@
 # status bar
 set-option -g status-utf8 on
 
+# disable automatic rename
+set-option -g allow-rename off
 
 # https://github.com/seebi/tmux-colors-solarized/blob/master/tmuxcolors-256.conf
 set-option -g status-bg colour235 #base02


### PR DESCRIPTION
by default tmux renames windows depending on the process currently running
