### PR TITLE
automatically rename ssh tabs in tmux with their hostname

### DIFF
--- a/files/bashrc
+++ b/files/bashrc
@@ -37,6 +37,14 @@ fi
 # tmux stuff
 export TERM="xterm-256color"
 alias tmux="tmux -2"
+settitle() {
+    printf "\033k$1\033\\"
+}
+ssh() {
+    settitle "$*"
+    command ssh "$@"
+    settitle "bash"
+}
 
 if [ -f ~/.git-prompt.sh ]
     then

--- a/files/tmux.conf
+++ b/files/tmux.conf
@@ -5,9 +5,6 @@
 # status bar
 set-option -g status-utf8 on
 
-# disable automatic rename
-set-option -g allow-rename off
-
 # https://github.com/seebi/tmux-colors-solarized/blob/master/tmuxcolors-256.conf
 set-option -g status-bg colour235 #base02
 set-option -g status-fg colour136 #yellow


### PR DESCRIPTION
* replace ssh with a simple bash function
* name the tmux window with the arguments passed to ssh (normally just the hostname)