### PR TITLE
add vim tag files to gitignore

### DIFF
--- a/files/gitignore
+++ b/files/gitignore
@@ -5,3 +5,4 @@
 Session.vim
 tags.vendors
 .idea
+.tags*


### PR DESCRIPTION
new global gitignore patterns for vim users, putting exuberant ctags data in `.tags*` files