### PR TITLE
fast vim (without config)

### DIFF
--- a/files/bashrc
+++ b/files/bashrc
@@ -125,6 +125,8 @@ source ~/.bookmarks
 alias console='php app/console '
 alias sf='php bin/console '
 
+# fast vim (without config) for editing large files
+alias vim-fast='vim -u NONE'
 
 # www specials alias
 alias www='sudo -u www-data '


### PR DESCRIPTION
When editing large files (log files, sql dumps, ...) a fully fledged vim can be quite slow, when all you need is just to edit the file.

Therefore the `vim-fast` alias, which does not load any configuration.