### PR TITLE
tmux true color support

### DIFF
--- a/files/tmux.conf
+++ b/files/tmux.conf
@@ -60,4 +60,6 @@ set-option -g status-right "#[fg=colour239, bg=colour237, nobold, nounderscore, 
 set-window-option -g window-status-current-format "#[fg=colour239, bg=colour248, :nobold, noitalics, nounderscore]#[fg=colour239, bg=colour214] #I #[fg=colour239, bg=colour214, bold] #W #[fg=colour214, bg=colour237, nobold, noitalics, nounderscore]"
 set-window-option -g window-status-format "#[fg=colour237,bg=colour239,noitalics]#[fg=colour223,bg=colour239] #I #[fg=colour223, bg=colour239] #W #[fg=colour239, bg=colour237, noitalics]"
 
+# true color support, tmux >= 2.2
+set-option -ga terminal-overrides ",xterm-256color:Tc"
 


### PR DESCRIPTION
works in my setup with ubuntu 17.04, including vim (if `:set termguicolors` enabled)